### PR TITLE
Removed pipenv files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ __pycache__/
 venv/
 *.sqlite3
 .idea/
-Pipfile
-Pipfile.lock


### PR DESCRIPTION
As recommended in this article:  

https://pipenv-fork.readthedocs.io/en/latest/basics.html#general-recommendations-version-control

The `Pipfile` and `Pipfile.lock` should be commited to version control.  I removed these from `.gitignore`.