### PR TITLE
Bug Fix: Signup emails are unique to each registered user

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -8,5 +8,11 @@ class CustomAccount(AbstractUser):
     """Set custom user account fields"""
     emergency_email = models.EmailField(blank=True, max_length=254)
 
+    email = models.EmailField(
+            verbose_name='email address',
+            max_length=255,
+            unique=True,
+    )
+
     def __str__(self):
         return self.username


### PR DESCRIPTION
This fix ensures only one email can be used per registered user. I encountered this shortly after #15. I had 5 test accounts all with the same email, so one password reset made me spam myself...

Note: It is a change to the user account model so we will need to migrate again.