### PR TITLE
View Trips: In Progress/Upcoming/Past and update trip status

### DIFF
--- a/apps/pages/models.py
+++ b/apps/pages/models.py
@@ -18,7 +18,7 @@ class Trip(models.Model):
                                    related_name='trips')
     trip_location = models.CharField(max_length=30)
     trip_name = models.CharField(max_length=30)
-    trip_start =    models.DateTimeField()
+    trip_start = models.DateTimeField()
     trip_end = models.DateTimeField()
     trip_status = models.CharField(max_length=5,
                 choices=[(tag, tag.value) for tag in TripStatusList_])

--- a/apps/pages/urls.py
+++ b/apps/pages/urls.py
@@ -6,19 +6,45 @@ from . import views
 
 # Link 'pages' app urls to views
 urlpatterns = [
-    path('', views.HomePageView.as_view(), name='home'),
-    path('trips/', views.TripPageView.as_view(), name='trip_list'),
-    path('trips/add/', views.TripCreateView.as_view(), name='trip_create'),
-    path('password_reset/',
-         auth_views.PasswordResetView.as_view(),
-         name='password_reset'),
-    path('password_reset/done/',
-         auth_views.PasswordResetDoneView.as_view(),
-         name='password_reset_done'),
-    path('password_reset_confirm/',
-         auth_views.PasswordResetConfirmView.as_view(),
-         name='password_reset_confirm'),
-    path('reset/done/',
-         auth_views.PasswordResetCompleteView.as_view(),
-         name='password_reset_complete'),
+
+    # Homepage
+    path(
+        '',
+        views.HomePageView.as_view(),
+        name='home'
+    ),
+
+    # Add/View Trips
+    path(
+        'trips/',
+        views.TripPageView.as_view(),
+        name='trip_list'
+    ),
+    path(
+        'trips/add/',
+        views.TripCreateView.as_view(),
+        name='trip_create'
+    ),
+
+    # Password Reset
+    path(
+        'password_reset/',
+        auth_views.PasswordResetView.as_view(),
+        name='password_reset'
+    ),
+    path(
+        'password_reset/done/',
+        auth_views.PasswordResetDoneView.as_view(),
+        name='password_reset_done'
+    ),
+    path(
+        'password_reset_confirm/',
+        auth_views.PasswordResetConfirmView.as_view(),
+        name='password_reset_confirm'
+    ),
+    path(
+        'reset/done/',
+        auth_views.PasswordResetCompleteView.as_view(),
+        name='password_reset_complete'
+    ),
 ]

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -46,7 +46,7 @@ class TripPageView(LoginRequiredMixin, ListView):
                 trip_end__lt=datetime.now()
             )
         }
-        # Update trip status for each query set
+        # Update trip status for each query
         for key, val in queryset.items():
             trips_set = queryset[key]
             if key == 'in_progress':
@@ -68,5 +68,4 @@ class TripCreateView(LoginRequiredMixin, CreateView):
 
     def form_valid(self, form):
         form.instance.trip_owner = self.request.user
-        form.instance.trip_status = "Yet to start"
         return super().form_valid(form)

--- a/templates/trip_view.html
+++ b/templates/trip_view.html
@@ -31,7 +31,7 @@
                             <th scope="col"></th>
                         </tr>
                     </thead>
-                    {% for trip in object_list %}
+                    {% for trip in trips.in_progress %}
                         <!-- {% if trip.start_date == now %} -->
                         <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>
@@ -82,7 +82,7 @@
                             <th scope="col"></th>
                         </tr>
                     </thead>
-                    {% for trip in object_list %}
+                    {% for trip in trips.upcoming %}
                         <!-- {% if trip.start_date == now %} -->
                         <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>
@@ -132,7 +132,7 @@
                             <th scope="col"></th>
                         </tr>
                     </thead>
-                    {% for trip in object_list %}
+                    {% for trip in trips.past %}
                         <!-- {% if trip.start_date == now %} -->
                         <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>

--- a/templates/trip_view.html
+++ b/templates/trip_view.html
@@ -32,8 +32,6 @@
                         </tr>
                     </thead>
                     {% for trip in trips.in_progress %}
-                        <!-- {% if trip.start_date == now %} -->
-                        <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>
                             <tr>
                                 <th scope="row">{{ forloop.counter }}</th>
@@ -50,7 +48,6 @@
                                 </td>
                             </tr>
                         </tbody>
-                        {% endif %}
                     {% endfor %}
                 </table>
             </div>
@@ -83,8 +80,6 @@
                         </tr>
                     </thead>
                     {% for trip in trips.upcoming %}
-                        <!-- {% if trip.start_date == now %} -->
-                        <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>
                             <tr>
                                 <th scope="row">{{ forloop.counter }}</th>
@@ -101,7 +96,6 @@
                                 </td>
                             </tr>
                         </tbody>
-                        {% endif %}
                     {% endfor %}
                 </table>
             </div>
@@ -133,8 +127,6 @@
                         </tr>
                     </thead>
                     {% for trip in trips.past %}
-                        <!-- {% if trip.start_date == now %} -->
-                        <!-- <td>{% now "F d, H:m Y-m-d:F" %}</td> -->
                         <tbody>
                             <tr>
                                 <th scope="row">{{ forloop.counter }}</th>
@@ -151,15 +143,10 @@
                                 </td>
                             </tr>
                         </tbody>
-                        {% endif %}
                     {% endfor %}
                 </table>
               </div>
             </div>
           </div>
     </div>
-
-
-
-      
 {% endblock %}


### PR DESCRIPTION
**Updates:**

- The 'View Trips' page should correctly filter trips into different categories based on their start/end dates.
- The `trip_status` field for every trip should automatically update from: In Progress / Yet to start / Competed

**Quick look:**
![image](https://user-images.githubusercontent.com/39935686/85478354-4c0fde00-b579-11ea-8d69-9838a6a53c4d.png)

**Notes:**
- This works at the view-level by creating a dict of querysets for each trip status based on the trip's start/end dates relative to the current date. 
- The trip_status field is updated by calling `update(trip_status='')` on each queryset
- I re-formatted pages/urls.py in an effort to make it more legible