### PR TITLE
View Trips: Timezone fix and sort trips by start date

### DIFF
--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -3,7 +3,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import TemplateView, ListView
 from django.views.generic.edit import CreateView
 from django.urls import reverse_lazy
-from datetime import datetime, timedelta
+from django.utils import timezone
+from datetime import timedelta
 from .forms import TripCreateForm
 from .models import Trip
 
@@ -31,19 +32,19 @@ class TripPageView(LoginRequiredMixin, ListView):
             # In Progress
             'in_progress': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_start__lte=datetime.now(),
-                trip_end__gt=datetime.now()
+                trip_start__lte=timezone.now(),
+                trip_end__gt=timezone.now()
             ),
             # Upcoming
             'upcoming': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_start__gt=datetime.now(),
-                trip_end__lte=(datetime.now() + timedelta(7))
+                trip_start__gt=timezone.now(),
+                trip_end__lte=(timezone.now() + timedelta(7))
             ),
             # Past
             'past': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_end__lt=datetime.now()
+                trip_end__lt=timezone.now()
             )
         }
         # Update trip status for each query

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -24,28 +24,29 @@ class TripPageView(LoginRequiredMixin, ListView):
 
     # Trip querysets for each trip status
     def get_queryset(self):
+        now = timezone.now()
         queryset = {
             # All
             'all': Trip.objects.filter(
                 trip_owner=self.request.user
-            ),
+            ).order_by('trip_start'),
             # In Progress
             'in_progress': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_start__lte=timezone.now(),
-                trip_end__gt=timezone.now()
-            ),
+                trip_start__lte=now,
+                trip_end__gt=now
+            ).order_by('trip_start'),
             # Upcoming
             'upcoming': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_start__gt=timezone.now(),
-                trip_end__lte=(timezone.now() + timedelta(7))
-            ),
+                trip_start__gt=now,
+                trip_end__lte=(now + timedelta(7))
+            ).order_by('trip_start'),
             # Past
             'past': Trip.objects.filter(
                 trip_owner=self.request.user,
-                trip_end__lt=timezone.now()
-            )
+                trip_end__lt=now
+            ).order_by('trip_start')
         }
         # Update trip status for each query
         for key, val in queryset.items():


### PR DESCRIPTION
This is a quick fix to the last merged branch #38 which used timezone naiive date time objects. More info:

[Timezone naiive datetime objects](https://docs.djangoproject.com/en/3.0/topics/i18n/timezones/#concepts)

I also added a very minor change that sorts trips in each section by start date.