### PR TITLE
Added emergency contact error text CSS

### DIFF
--- a/static/css/_base.css
+++ b/static/css/_base.css
@@ -15,6 +15,11 @@ h1,h2,h3,h4,h5,h6 {
     /* font-weight: bold; */
 }
 
+.contact-error {
+    font-family: 'PT Sans', sans-serif;
+    color: crimson;
+}
+
 .accordian-border {
     border-bottom: 3px solid #f62
 }


### PR DESCRIPTION
Just some CSS to make the error text appear red:

![image](https://user-images.githubusercontent.com/39935686/85803405-53172780-b704-11ea-8a4d-c3ee51051382.png)

I thought I included this in #42 not sure how it got left out.