### PR TITLE
Removed emergency_email field from CustomAccount model

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -1,14 +1,11 @@
 # apps/accounts/models.py
 from django.db import models
 from django.contrib.auth.models import AbstractUser
-from enum import Enum
 
 
 # Create custom accounts for the database
 class CustomAccount(AbstractUser):
     """Set custom user account fields"""
-    emergency_email = models.EmailField(blank=True, max_length=254)
-
     email = models.EmailField(
             verbose_name='email address',
             max_length=255,


### PR DESCRIPTION
Since we are using a dedicated model for emergency contacts, we no longer need an `emergency_contact` field in our CustomAccount model. 