### PR TITLE
Fixes: trip end date cannot be before start date, trip dates visible when editing trip

### DIFF
--- a/apps/pages/forms.py
+++ b/apps/pages/forms.py
@@ -24,7 +24,7 @@ class TripCreateForm(forms.ModelForm):
         required=True,
         input_formats=['%Y-%m-%dT%H:%M'],
         widget=forms.DateTimeInput(
-            format='%Y-%m-%d %H:%M',
+            format='%Y-%m-%dT%H:%M',
             attrs={'type': 'datetime-local'}
         )
     )
@@ -34,7 +34,7 @@ class TripCreateForm(forms.ModelForm):
         required=True,
         input_formats=['%Y-%m-%dT%H:%M'],
         widget=forms.DateTimeInput(
-            format='%Y-%m-%d %H:%M',
+            format='%Y-%m-%dT%H:%M',
             attrs={'type': 'datetime-local'}
         )
     )
@@ -80,7 +80,7 @@ class TripUpdateForm(forms.ModelForm):
         required=True,
         input_formats=['%Y-%m-%dT%H:%M'],
         widget=forms.DateTimeInput(
-            format='%Y-%m-%d %H:%M',
+            format='%Y-%m-%dT%H:%M',
             attrs={'type': 'datetime-local'}
         )
     )
@@ -90,7 +90,7 @@ class TripUpdateForm(forms.ModelForm):
         required=True,
         input_formats=['%Y-%m-%dT%H:%M'],
         widget=forms.DateTimeInput(
-            format='%Y-%m-%d %H:%M',
+            format='%Y-%m-%dT%H:%M',
             attrs={'type': 'datetime-local'}
         )
     )

--- a/apps/pages/forms.py
+++ b/apps/pages/forms.py
@@ -39,6 +39,25 @@ class TripCreateForm(forms.ModelForm):
         )
     )
 
+    # Validate form fields
+    def clean(self):
+        form_data = super().clean()
+        trip_start = form_data.get('trip_start')
+        trip_end = form_data.get('trip_end')
+
+        # Raise an error if trip_start > trip_end
+        if trip_start > trip_end:
+            self.add_error(
+                'trip_start',
+                'Error: Start date must be before end date'
+            )
+            self.add_error(
+                'trip_end',
+                'Error: End date must be after start date.'
+            )
+            raise forms.ValidationError('invalid')
+        return self.cleaned_data
+
 
 # Form used to update trips
 class TripUpdateForm(forms.ModelForm):
@@ -76,6 +95,25 @@ class TripUpdateForm(forms.ModelForm):
         )
     )
 
+    # Validate form fields
+    def clean(self):
+        form_data = super().clean()
+        trip_start = form_data.get('trip_start')
+        trip_end = form_data.get('trip_end')
+
+        # Raise an error if trip_start > trip_end
+        if trip_start > trip_end:
+            self.add_error(
+                'trip_start',
+                'Error: Start date must be before end date'
+            )
+            self.add_error(
+                'trip_end',
+                'Error: End date must be after start date.'
+            )
+            raise forms.ValidationError('invalid')
+        return self.cleaned_data
+
 
 # Form to add emergency contact information
 class EmergencyContactForm(forms.ModelForm):
@@ -86,6 +124,7 @@ class EmergencyContactForm(forms.ModelForm):
             'last_name',
             'email',
         ]
+
 
 # Form to update emergency contact information
 class EmergencyContactUpdateForm(forms.ModelForm):

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.contrib import messages
 from datetime import timedelta
 from .forms import TripCreateForm, TripUpdateForm, EmergencyContactForm, EmergencyContactUpdateForm
-from .models import Trip, EmergencyContact
+from .models import Trip, EmergencyContact, TripStatusList_
 
 
 #  Render the homepage
@@ -53,15 +53,22 @@ class TripPageView(LoginRequiredMixin, ListView):
                 trip_end__lt=now
             ).order_by('trip_start')
         }
+
         # Update trip status for each query
         for key, val in queryset.items():
             trips_set = queryset[key]
             if key == 'in_progress':
-                trips_set.update(trip_status="In progress")
+                trips_set.update(
+                    trip_status=TripStatusList_.IP.value
+                )
             if key == 'upcoming':
-                trips_set.update(trip_status="Yet to start")
+                trips_set.update(
+                    trip_status=TripStatusList_.YTS.value
+                )
             if key == 'past':
-                trips_set.update(trip_status="Completed")
+                trips_set.update(
+                    trip_status=TripStatusList_.CP.value
+                )
         return queryset
 
 

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -7,7 +7,8 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.contrib import messages
 from datetime import timedelta
-from .forms import TripCreateForm, TripUpdateForm, EmergencyContactForm, EmergencyContactUpdateForm
+from .forms import TripCreateForm, TripUpdateForm
+from .forms import EmergencyContactForm, EmergencyContactUpdateForm
 from .models import Trip, EmergencyContact, TripStatusList_
 
 
@@ -138,8 +139,8 @@ class EmergencyContactPageView(LoginRequiredMixin, ListView):
     login_url = '/accounts/login/'
     context_object_name = 'emergency_contacts'
 
-    def get_query_set(self):
-        return self.EmergencyContact.objects.filter(user=self.request.user)
+    def get_queryset(self):
+        return EmergencyContact.objects.filter(user=self.request.user)
 
 
 class EmergencyContactUpdateView(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
Addresses issues: #55 #56 #58 
As we discussed on slack today, this keeps the `TripUpdateForm` and `EmergencyContactUpdateForm` in apps/pages/forms.py